### PR TITLE
Resolves #40 - Exception when text long or terminal small

### DIFF
--- a/modules/testpackage/src/main/java/org/testpackage/ColouredOutputRunListener.java
+++ b/modules/testpackage/src/main/java/org/testpackage/ColouredOutputRunListener.java
@@ -337,8 +337,13 @@ public class ColouredOutputRunListener extends RunListener implements StreamSour
         String cleansedLeftString = leftString.replaceAll("@\\|[\\w,]+\\s|\\|@", "");
         String cleansedRightString = rightString.replaceAll("@\\|[\\w,]+\\s|\\|@", "");
 
-        int space = terminalWidth - (cleansedLeftString.length() + cleansedRightString.length());
-
-        return leftString + Strings.repeat(" ", space) + rightString;
+        int spaces = 0;
+        if (terminalWidth > 0) {
+            // Leftover after left and right string together wraps the terminal
+            int leftoverFromLeftAndRight = (cleansedLeftString.length() + cleansedRightString.length()) % terminalWidth;
+            // Get the number of spaces to fill the rest of the terminal
+            spaces = terminalWidth - leftoverFromLeftAndRight;
+        }
+        return leftString + Strings.repeat(" ", spaces) + rightString;
     }
 }


### PR DESCRIPTION
- Modified math for calculating the number of spaces to add
  for right aligning the result text
- Allowed for wrapping of the descriptions and still right
  aligning the resulting text on either that line, or the
  next line if still too long.