### PR TITLE
Resolves #7 - Allow grouping of integration tests

### DIFF
--- a/modules/testpackage/src/main/java/org/testpackage/TestSequencer.java
+++ b/modules/testpackage/src/main/java/org/testpackage/TestSequencer.java
@@ -45,9 +45,18 @@ public class TestSequencer {
     public Request sequenceTests(Map<String, Integer> runsSinceLastFailures, String... testPackageNames) throws IOException {
         List<Class<?>> testClasses = Lists.newArrayList();
 
+        ClassPath classpath = ClassPath.from(TestPackage.class.getClassLoader());
+
         for (String testPackageName : testPackageNames) {
-            ClassPath classpath = ClassPath.from(TestPackage.class.getClassLoader());
-            for (ClassPath.ClassInfo classInfo : classpath.getTopLevelClasses(testPackageName)) {
+            testPackageName = testPackageName.replace(".", "\\.");
+            testPackageName = testPackageName.replace("*", ".*");
+
+            for (ClassPath.ClassInfo classInfo : classpath.getTopLevelClasses()) {
+                String packageName = classInfo.getPackageName();
+                if (!packageName.matches(testPackageName)) {
+                    continue;
+                }
+
                 final Class<?> theClass = classInfo.load();
 
                 final int modifiers = theClass.getModifiers();

--- a/modules/testpackage/src/test/java/org/testpackage/runnertest/wildcards/SimpleTest.java
+++ b/modules/testpackage/src/test/java/org/testpackage/runnertest/wildcards/SimpleTest.java
@@ -1,0 +1,19 @@
+package org.testpackage.runnertest.wildcards;
+
+import org.junit.Test;
+
+/**
+ * This is supposed to have the same class name in all 'wildcards' packages.
+ */
+public class SimpleTest {
+
+    @Test
+    public void testTrue2() {
+        assert true;
+    }
+
+    @Test
+    public void testTrue1() {
+        assert true;
+    }
+}

--- a/modules/testpackage/src/test/java/org/testpackage/runnertest/wildcards/exclude1/SimpleTest.java
+++ b/modules/testpackage/src/test/java/org/testpackage/runnertest/wildcards/exclude1/SimpleTest.java
@@ -1,0 +1,19 @@
+package org.testpackage.runnertest.wildcards.exclude1;
+
+import org.junit.Test;
+
+/**
+ * This is supposed to have the same class name in all 'wildcards' packages.
+ */
+public class SimpleTest {
+
+    @Test
+    public void testTrue2() {
+        assert true;
+    }
+
+    @Test
+    public void testTrue1() {
+        assert true;
+    }
+}

--- a/modules/testpackage/src/test/java/org/testpackage/runnertest/wildcards/include1/SimpleTest.java
+++ b/modules/testpackage/src/test/java/org/testpackage/runnertest/wildcards/include1/SimpleTest.java
@@ -1,0 +1,19 @@
+package org.testpackage.runnertest.wildcards.include1;
+
+import org.junit.Test;
+
+/**
+ * This is supposed to have the same class name in all 'wildcards' packages.
+ */
+public class SimpleTest {
+
+    @Test
+    public void testTrue2() {
+        assert true;
+    }
+
+    @Test
+    public void testTrue1() {
+        assert true;
+    }
+}

--- a/modules/testpackage/src/test/java/org/testpackage/runnertest/wildcards/include1/includesub1/SimpleTest.java
+++ b/modules/testpackage/src/test/java/org/testpackage/runnertest/wildcards/include1/includesub1/SimpleTest.java
@@ -1,0 +1,19 @@
+package org.testpackage.runnertest.wildcards.include1.includesub1;
+
+import org.junit.Test;
+
+/**
+ * This is supposed to have the same class name in all 'wildcards' packages.
+ */
+public class SimpleTest {
+
+    @Test
+    public void testTrue2() {
+        assert true;
+    }
+
+    @Test
+    public void testTrue1() {
+        assert true;
+    }
+}

--- a/modules/testpackage/src/test/java/org/testpackage/runnertest/wildcards/include1/includesub2/SimpleTest.java
+++ b/modules/testpackage/src/test/java/org/testpackage/runnertest/wildcards/include1/includesub2/SimpleTest.java
@@ -1,0 +1,19 @@
+package org.testpackage.runnertest.wildcards.include1.includesub2;
+
+import org.junit.Test;
+
+/**
+ * This is supposed to have the same class name in all 'wildcards' packages.
+ */
+public class SimpleTest {
+
+    @Test
+    public void testTrue2() {
+        assert true;
+    }
+
+    @Test
+    public void testTrue1() {
+        assert true;
+    }
+}

--- a/modules/testpackage/src/test/java/org/testpackage/runnertest/wildcards/include2/SimpleTest.java
+++ b/modules/testpackage/src/test/java/org/testpackage/runnertest/wildcards/include2/SimpleTest.java
@@ -1,0 +1,19 @@
+package org.testpackage.runnertest.wildcards.include2;
+
+import org.junit.Test;
+
+/**
+ * This is supposed to have the same class name in all 'wildcards' packages.
+ */
+public class SimpleTest {
+
+    @Test
+    public void testTrue2() {
+        assert true;
+    }
+
+    @Test
+    public void testTrue1() {
+        assert true;
+    }
+}

--- a/modules/testpackage/src/test/java/org/testpackage/test/TestSequencerTest.java
+++ b/modules/testpackage/src/test/java/org/testpackage/test/TestSequencerTest.java
@@ -63,7 +63,7 @@ public class TestSequencerTest {
 
     @Test
     public void testWildcardOfMiddleOfPackageContains() throws IOException {
-        Request request = new TestSequencer().sequenceTests("org.testpackage.runnertest.wildcards.*.includesub");
+        Request request = new TestSequencer().sequenceTests("org.testpackage.runnertest.wildcards.*.includesub*");
 
         assertEquals("the request contains the right number of test methods", 4, request.getRunner().testCount());
         assertEquals("the request has the test methods in lexicographic order (1/4)", "testTrue1(org.testpackage.runnertest.wildcards.include1.includesub1.SimpleTest)", request.getRunner().getDescription().getChildren().get(0).getChildren().get(0).getDisplayName());

--- a/modules/testpackage/src/test/java/org/testpackage/test/TestSequencerTest.java
+++ b/modules/testpackage/src/test/java/org/testpackage/test/TestSequencerTest.java
@@ -35,7 +35,41 @@ public class TestSequencerTest {
         assertEquals("the request contains the right number of test methods", 2, request.getRunner().testCount());
         assertEquals("the request has the test methods in lexicographic order (1/2)", "testTrue1(org.testpackage.runnertest.simpletests.SimpleTest)", request.getRunner().getDescription().getChildren().get(0).getChildren().get(0).getDisplayName());
         assertEquals("the request has the test methods in lexicographic order (2/2)", "testTrue2(org.testpackage.runnertest.simpletests.SimpleTest)", request.getRunner().getDescription().getChildren().get(0).getChildren().get(1).getDisplayName());
+    }
 
+    @Test
+    public void testWildcardOfEndOfPackageContains() throws IOException {
+        Request request = new TestSequencer().sequenceTests("org.testpackage.runnertest.wildcards.include*");
+
+        assertEquals("the request contains the right number of test methods", 8, request.getRunner().testCount());
+        assertEquals("the request has the test methods in lexicographic order (1/8)", "testTrue1(org.testpackage.runnertest.wildcards.include1.SimpleTest)", request.getRunner().getDescription().getChildren().get(0).getChildren().get(0).getDisplayName());
+        assertEquals("the request has the test methods in lexicographic order (2/8)", "testTrue2(org.testpackage.runnertest.wildcards.include1.SimpleTest)", request.getRunner().getDescription().getChildren().get(0).getChildren().get(1).getDisplayName());
+        assertEquals("the request has the test methods in lexicographic order (3/8)", "testTrue1(org.testpackage.runnertest.wildcards.include1.includesub1.SimpleTest)", request.getRunner().getDescription().getChildren().get(1).getChildren().get(0).getDisplayName());
+        assertEquals("the request has the test methods in lexicographic order (4/8)", "testTrue2(org.testpackage.runnertest.wildcards.include1.includesub1.SimpleTest)", request.getRunner().getDescription().getChildren().get(1).getChildren().get(1).getDisplayName());
+        assertEquals("the request has the test methods in lexicographic order (5/8)", "testTrue1(org.testpackage.runnertest.wildcards.include1.includesub2.SimpleTest)", request.getRunner().getDescription().getChildren().get(2).getChildren().get(0).getDisplayName());
+        assertEquals("the request has the test methods in lexicographic order (6/8)", "testTrue2(org.testpackage.runnertest.wildcards.include1.includesub2.SimpleTest)", request.getRunner().getDescription().getChildren().get(2).getChildren().get(1).getDisplayName());
+        assertEquals("the request has the test methods in lexicographic order (7/8)", "testTrue1(org.testpackage.runnertest.wildcards.include2.SimpleTest)", request.getRunner().getDescription().getChildren().get(3).getChildren().get(0).getDisplayName());
+        assertEquals("the request has the test methods in lexicographic order (8/8)", "testTrue2(org.testpackage.runnertest.wildcards.include2.SimpleTest)", request.getRunner().getDescription().getChildren().get(3).getChildren().get(1).getDisplayName());
+    }
+
+    @Test
+    public void testPackageContains() throws IOException {
+        Request request = new TestSequencer().sequenceTests("org.testpackage.runnertest.wildcards");
+
+        assertEquals("the request contains the right number of test methods", 2, request.getRunner().testCount());
+        assertEquals("the request has the test methods in lexicographic order (1/2)", "testTrue1(org.testpackage.runnertest.wildcards.SimpleTest)", request.getRunner().getDescription().getChildren().get(0).getChildren().get(0).getDisplayName());
+        assertEquals("the request has the test methods in lexicographic order (2/2)", "testTrue2(org.testpackage.runnertest.wildcards.SimpleTest)", request.getRunner().getDescription().getChildren().get(0).getChildren().get(1).getDisplayName());
+    }
+
+    @Test
+    public void testWildcardOfMiddleOfPackageContains() throws IOException {
+        Request request = new TestSequencer().sequenceTests("org.testpackage.runnertest.wildcards.*.includesub");
+
+        assertEquals("the request contains the right number of test methods", 4, request.getRunner().testCount());
+        assertEquals("the request has the test methods in lexicographic order (1/4)", "testTrue1(org.testpackage.runnertest.wildcards.include1.includesub1.SimpleTest)", request.getRunner().getDescription().getChildren().get(0).getChildren().get(0).getDisplayName());
+        assertEquals("the request has the test methods in lexicographic order (2/4)", "testTrue2(org.testpackage.runnertest.wildcards.include1.includesub1.SimpleTest)", request.getRunner().getDescription().getChildren().get(0).getChildren().get(1).getDisplayName());
+        assertEquals("the request has the test methods in lexicographic order (3/4)", "testTrue1(org.testpackage.runnertest.wildcards.include1.includesub2.SimpleTest)", request.getRunner().getDescription().getChildren().get(1).getChildren().get(0).getDisplayName());
+        assertEquals("the request has the test methods in lexicographic order (4/4)", "testTrue2(org.testpackage.runnertest.wildcards.include1.includesub2.SimpleTest)", request.getRunner().getDescription().getChildren().get(1).getChildren().get(1).getDisplayName());
     }
 
     @Test


### PR DESCRIPTION
- Modified TestSequencer to allow for wildcards on package names.
  **Note**: This can match on multiple packages if the wildcard is in the middle. Look at tests for examples.